### PR TITLE
:+1: EscapeされたHTML特殊文字をもとに戻す

### DIFF
--- a/internal/1702965451712819281.json
+++ b/internal/1702965451712819281.json
@@ -1,0 +1,39 @@
+{
+  "__typename": "Tweet",
+  "lang": "ja",
+  "favorite_count": 0,
+  "created_at": "2023-09-16T08:39:37.000Z",
+  "display_text_range": [
+    0,
+    116
+  ],
+  "entities": {
+    "hashtags": [],
+    "urls": [],
+    "user_mentions": [],
+    "symbols": []
+  },
+  "id_str": "1702965451712819281",
+  "text": "&amp;quot;\"\"\"クォーテーション&amp;amp;\"&amp;\"アンパサンド&amp;lt;\"&lt;\"小なり&amp;gt;\"&gt;\"大なり&amp;nbsp;\" \"空白&amp;copy;\"©\"コピーライト\n\nテスト",
+  "user": {
+    "id_str": "1422436845351149570",
+    "name": "BcS114",
+    "profile_image_url_https": "https://pbs.twimg.com/profile_images/1588816769770131456/w9GUIIuP_normal.jpg",
+    "screen_name": "YSurarin",
+    "verified": false,
+    "is_blue_verified": false,
+    "profile_image_shape": "Circle"
+  },
+  "edit_control": {
+    "edit_tweet_ids": [
+      "1702965451712819281"
+    ],
+    "editable_until_msecs": "1694857177000",
+    "is_edit_eligible": true,
+    "edits_remaining": "5"
+  },
+  "conversation_count": 0,
+  "news_action_type": "conversation",
+  "isEdited": false,
+  "isStaleEdit": false
+}

--- a/internal/__snapshots__/processTweet.test.ts.snap
+++ b/internal/__snapshots__/processTweet.test.ts.snap
@@ -457,3 +457,23 @@ snapshot[`processTweet() > (@FloodSocial) It's time  1`] = `
   replyCount: 0,
 }
 `;
+
+snapshot[`processTweet() > (@YSurarin) &amp;quot; 1`] = `
+{
+  author: {
+    name: "BcS114",
+    screenName: "YSurarin",
+  },
+  content: [
+    {
+      text: '&quot;"""クォーテーション&amp;"&"アンパサンド&lt;"<"小なり&gt;">"大なり&nbsp;" "空白&copy;"©"コピーライト
+
+テスト',
+      type: "plain",
+    },
+  ],
+  id: "1702965451712819281",
+  posted: 2023-09-16T08:39:37.000Z,
+  replyCount: 0,
+}
+`;

--- a/internal/processTweet.test.ts
+++ b/internal/processTweet.test.ts
@@ -6,6 +6,9 @@ import type { RefTweet, Tweet } from "./getTweet.ts";
 import tweet from "./1572401761092239362.json" assert { type: "json" };
 import tweetWithGIF from "./1162409260627611648.json" assert { type: "json" };
 import tweetWithOGP from "./1168966000135606274.json" assert { type: "json" };
+import tweetWithSpecialCharacters from "./1702965451712819281.json" assert {
+  type: "json",
+};
 
 Deno.test("processTweet()", async (t) => {
   for (
@@ -15,6 +18,7 @@ Deno.test("processTweet()", async (t) => {
       tweetWithGIF,
       tweetWithGIF.quoted_tweet,
       tweetWithOGP,
+      tweetWithSpecialCharacters,
     ]
   ) {
     await t.step(

--- a/internal/processTweet.ts
+++ b/internal/processTweet.ts
@@ -1,4 +1,5 @@
 import type { RefTweet, Tweet } from "./getTweet.ts";
+import { unescapeHTML } from "./unescapeHTML.ts";
 
 /** APIから取得したTweet objectを、使いやすいよう変換して返す
  *
@@ -89,19 +90,21 @@ export const processTweet = (
     ) ?? [],
   ].sort((a, b) => a.indices[0] - b.indices[0]);
 
-  let offset = 0;
-  let text = tweet.text;
   const content: TweetNode[] = [];
-  for (const { indices, ...entity } of entities) {
-    const before = [...text].slice(0, indices[0] - offset).join("");
-    content.push({ type: "plain", text: before });
+  {
+    let offset = 0;
+    let text = tweet.text;
+    for (const { indices, ...entity } of entities) {
+      const before = [...text].slice(0, indices[0] - offset).join("");
+      content.push({ type: "plain", text: unescapeHTML(before) });
 
-    content.push(entity);
+      content.push(entity);
 
-    text = [...text].slice(indices[1] - offset).join("");
-    offset = indices[1];
+      text = [...text].slice(indices[1] - offset).join("");
+      offset = indices[1];
+    }
+    if (text) content.push({ type: "plain", text: unescapeHTML(text) });
   }
-  if (text) content.push({ type: "plain", text });
 
   const processed: ProcessedTweet = {
     id: tweet.id_str,

--- a/internal/unescapeHTML.ts
+++ b/internal/unescapeHTML.ts
@@ -1,0 +1,18 @@
+const map = {
+  "&lt;": "<",
+  "&gt;": ">",
+  "&amp;": "&",
+  "&quot;": '"',
+  "&#x27;": "'",
+  "&#x60;": "`",
+};
+
+/** unescape notable HTML special characters
+ *
+ * cf. https://shanabrian.com/web/javascript/unescape-html.php
+ */
+export const unescapeHTML = (text: string): string =>
+  text.replace(
+    /&(lt|gt|amp|quot|#x27|#x60);/g,
+    (match) => map[match as keyof typeof map],
+  );


### PR DESCRIPTION
see [url-customizerでtweetを展開する際に絵文字が入っているとバグる](https://scrapbox.io/villagepump/url-customizerでtweetを展開する際に絵文字が入っているとバグる#650568e35f1e0d000031907e)