### PR TITLE
:bug: streaming形式の動画URLを使ってしまっていた

### DIFF
--- a/internal/getTweet.ts
+++ b/internal/getTweet.ts
@@ -225,7 +225,7 @@ export interface MediaDetail extends UrlEntity {
   video_info?: {
     aspect_ratio: [number, number];
     duration_millis?: number;
-    variants: { bitrate: number; content_type: string; url: string }[];
+    variants: { bitrate?: number; content_type: string; url: string }[];
   };
 }
 

--- a/internal/processTweet.ts
+++ b/internal/processTweet.ts
@@ -80,7 +80,7 @@ export const processTweet = (
               type: detail.type,
               url: new URL(
                 detail.video_info?.variants?.sort?.((a, b) =>
-                  b.bitrate - a.bitrate
+                  (b.bitrate ?? 0) - (a.bitrate ?? 0)
                 )?.[0].url ?? detail.media_url_https,
               ),
             }]


### PR DESCRIPTION
`bitrate`のあるなしでstreaming形式かどうか判定できるので、それを使ってdownload形式のURLを取り出す

see [url-customizerでtweetを展開する際に絵文字が入っているとバグる](https://scrapbox.io/villagepump/url-customizerでtweetを展開する際に絵文字が入っているとバグる)