### PR TITLE
:sparkles: convert x.com as a tweet

### DIFF
--- a/middlewares/formatTweet.ts
+++ b/middlewares/formatTweet.ts
@@ -14,7 +14,7 @@ export const formatTweet = (
 (url) => {
   // from https://scrapbox.io/asset/index.js
   const [, id] = url.href.match(
-    /^https:\/\/(?:www\.|mobile\.|m\.|)twitter\.com\/[\w\d_]+\/(?:status|statuses)\/(\d+)/,
+    /^https:\/\/(?:(?:www\.|mobile\.|m\.)?twitter|x)\.com\/[\w\d_]+\/(?:status|statuses)\/(\d+)/,
   ) ?? [];
   if (!id) return url;
 


### PR DESCRIPTION
close [tweet変換でx.comに対応する-.@2023-09-28](https://scrapbox.io/takker/tweet変換でx.comに対応する-.@2023-09-28)