### PR TITLE
fix(tweet): format tweets correctly even if there's no `GM_fetch`

### DIFF
--- a/deps/scrapbox-rest.ts
+++ b/deps/scrapbox-rest.ts
@@ -1,2 +1,2 @@
 export * from "https://raw.githubusercontent.com/takker99/scrapbox-userscript-std/0.24.3/rest/mod.ts";
-export * from "https://raw.githubusercontent.com/scrapbox-jp/types/0.5.0/rest.ts";
+export * from "https://raw.githubusercontent.com/scrapbox-jp/types/0.6.0/rest.ts";

--- a/deps/scrapbox.ts
+++ b/deps/scrapbox.ts
@@ -1,4 +1,4 @@
 export * from "https://raw.githubusercontent.com/takker99/scrapbox-userscript-std/0.24.3/browser/dom/mod.ts";
 export * from "https://raw.githubusercontent.com/takker99/scrapbox-userscript-std/0.24.3/title.ts";
-export type { Scrapbox } from "https://raw.githubusercontent.com/scrapbox-jp/types/0.5.0/userscript.ts";
-export * from "https://raw.githubusercontent.com/scrapbox-jp/types/0.5.0/rest.ts";
+export type { Scrapbox } from "https://raw.githubusercontent.com/scrapbox-jp/types/0.6.0/userscript.ts";
+export * from "https://raw.githubusercontent.com/scrapbox-jp/types/0.6.0/rest.ts";

--- a/middlewares/formatTweet.ts
+++ b/middlewares/formatTweet.ts
@@ -39,9 +39,7 @@ const defaultFormat = async (
 ): Promise<string> => {
   if ("images" in tweet) {
     return [
-      `[${escapeForEmbed(tweet.screenName)}(@${
-        escapeForEmbed(tweet.userName)
-      }) ${url.origin}${url.pathname}]`,
+      `[@${escapeForEmbed(tweet.screenName)} ${url.origin}${url.pathname}]`,
       ...tweet.description.split("\n").map((line) =>
         `> ${escapeForEmbed(line)}`
       ),
@@ -71,9 +69,7 @@ const stringify = async ({ content, author, id }: ProcessedTweet) => {
   const url = new URL(`https://twitter.com/${author.screenName}/status/${id}`);
 
   return [
-    `[${escapeForEmbed(author.name)}(@${
-      escapeForEmbed(author.screenName)
-    }) ${url}]`,
+    `[@${escapeForEmbed(author.screenName)} ${url}]`,
     ...(await Promise.all(content.map(async (node) => {
       switch (node.type) {
         case "plain":


### PR DESCRIPTION
ついでに、screenNameのみ表示するように、default formatを変更した