### PR TITLE
fix(tweet): Keep up with the latest tweet regex in `assets/index.js`

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -3,6 +3,7 @@
   "specifiers": {
     "jsr:@core/unknownutil@4": "4.3.0",
     "jsr:@cosense/std@~0.29.9": "0.29.9",
+    "jsr:@cosense/types@0.10": "0.10.7",
     "jsr:@cosense/types@~0.10.7": "0.10.7",
     "jsr:@progfay/scrapbox-parser@9": "9.2.0",
     "jsr:@std/assert@^1.0.10": "1.0.11",
@@ -30,7 +31,8 @@
       "integrity": "52ca573501d1004b2c31c422e61e728aa6cc9706c0d301790f9738240f0212b0",
       "dependencies": [
         "jsr:@core/unknownutil",
-        "jsr:@cosense/types",
+        "jsr:@cosense/types@0.10",
+        "jsr:@cosense/types@~0.10.7",
         "jsr:@progfay/scrapbox-parser",
         "jsr:@std/async",
         "jsr:@std/encoding",

--- a/middlewares/formatTweet.ts
+++ b/middlewares/formatTweet.ts
@@ -37,7 +37,7 @@ export const formatTweet = (
 (url) => {
   // from https://scrapbox.io/asset/index.js
   const [, id] = url.href.match(
-    /^https:\/\/(?:(?:www\.|mobile\.|m\.)?twitter|x)\.com\/[\w\d_]+\/(?:status|statuses)\/(\d+)/,
+    /^https:\/\/(?:www\.|mobile\.|m\.|)(?:twitter|x)\.com\/[A-Za-z0-9_]*\/(?:status|statuses)\/(\d+)/,
   ) ?? [];
   if (!id) return url;
 


### PR DESCRIPTION
cf. https://github.com/wogikaze/scrapbox-url-customizer/commit/a8ad835794565002308038c6f038a37bf884d272