### PR TITLE
Add formatter settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,14 @@
 {
   "deno.enable": true,
   "deno.lint": true,
-  "deno.unstable": []
+  "deno.unstable": [],
+  "[typescript]": {
+    "editor.defaultFormatter": "denoland.vscode-deno"
+  },
+  "[json]": {
+    "editor.defaultFormatter": "denoland.vscode-deno"
+  },
+  "[jsonc]": {
+    "editor.defaultFormatter": "denoland.vscode-deno"
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
   "deno.enable": true,
   "deno.lint": true,
-  "deno.unstable": true
+  "deno.unstable": []
 }


### PR DESCRIPTION
- `deno.unstable`設定のエラーを修正
- default formatter設定を追加
  - CIで使用している`deno fmt`と同じformattingをしてくれるDeno拡張機能を指定