### PR TITLE
Fix: Return converted result instead of original URL

### DIFF
--- a/convert.ts
+++ b/convert.ts
@@ -27,5 +27,5 @@ export const convert = (
         : middleware(prev),
     url as URL | string | Promise<URL | string>,
   );
-  return final instanceof Promise ? final.then((url) => `${url}`) : `${url}`;
+  return final instanceof Promise ? final.then((url) => `${url}`) : `${final}`;
 };


### PR DESCRIPTION
WikipediaのURLが変換できなかったので調査したところ、同期middlewareの場合に変換結果が無視され、元のURLが返されているようでした。
変換結果を返すように修正したところ、WikipediaのURLが正常に変換できるようになりました。